### PR TITLE
feat: upgrade to document-ir 0.4.0 with badge and footnote support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,11 +1,10 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "text-doc-ir",
       "dependencies": {
-        "document-ir": "0.3.0",
+        "document-ir": "0.4.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -188,7 +187,7 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "document-ir": ["document-ir@0.3.0", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-mWGkEPIp9VZ7S8+Xml5jydoEPgqiExUxULO+9/c47SKoFMhhRrfRIg6CnYS4C3nT30R1fNErCiReKn2Xh8bxow=="],
+    "document-ir": ["document-ir@0.4.0", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-i6guneOvxlYgd2fnlQ9eQGZBkKjyPFdPNk6JenamGiVESZ5NwZsjV7fhZ6tGrkHGaY3jkd3CfBZAtsLg+6hECg=="],
 
     "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 

--- a/example.json
+++ b/example.json
@@ -1,0 +1,44 @@
+{
+  "type": "document",
+  "title": "Lorem Ipsum with Footnotes",
+  "url": "/example",
+  "content": [
+    {
+      "type": "paragraph",
+      "content": [
+        { "type": "text", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit." },
+        {
+          "type": "footnote",
+          "content": [{ "type": "text", "text": "From the original Latin text by Cicero, De Finibus Bonorum et Malorum." }]
+        },
+        { "type": "text", "text": " Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris." }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "content": [
+        { "type": "text", "text": "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur." },
+        {
+          "type": "footnote",
+          "content": [{ "type": "text", "text": "This phrase is commonly used in typesetting since the 1500s." }]
+        },
+        { "type": "text", "text": " Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." },
+        {
+          "type": "footnote",
+          "content": [{ "type": "text", "text": "The standard Lorem Ipsum passage ends here." }]
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "content": [
+        { "type": "text", "text": "Curabitur pretium tincidunt lacus. Nulla gravida orci a odio." },
+        {
+          "type": "footnote",
+          "content": [{ "type": "text", "text": "Additional placeholder text beyond the classical excerpt." }]
+        },
+        { "type": "text", "text": " Nullam varius, turpis et commodo pharetra, est eros bibendum elit, nec luctus magna felis sollicitudin mauris." }
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "to-text": "bun src/to-text.ts"
   },
   "dependencies": {
-    "document-ir": "0.3.0"
+    "document-ir": "0.4.0"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/src/main.ts
+++ b/src/main.ts
@@ -122,18 +122,12 @@ export class FixedWidthTextVisitor extends NodeVisitor {
 
   protected override choose(node: Node): void {
     switch (node.type) {
-      case "badge":
-        return this.badge(node);
       case "code-block":
         return this.codeBlock(node);
       case "code-group":
         return this.codeGroup(node);
       case "accordion-group":
         return this.accordionGroup(node);
-      case "footnote":
-        return this.footnote(node);
-      case "footnote-display":
-        return this.footnoteDisplay(node);
       case "pill":
         return this.pill(node);
       case "style":
@@ -295,7 +289,7 @@ export class FixedWidthTextVisitor extends NodeVisitor {
     this.pushBlockContentEnd();
   }
 
-  protected badge(node: BadgeNode): void {
+  protected override badge(node: BadgeNode): void {
     let key: string;
     if (this.state.images.has(node.url)) {
       key = this.state.images.get(node.url) || "unreachable";
@@ -312,14 +306,14 @@ export class FixedWidthTextVisitor extends NodeVisitor {
     this.spaceLazy = true;
   }
 
-  protected footnote(node: FootnoteNode): void {
+  protected override footnote(node: FootnoteNode): void {
     this.state.footnoteCount++;
     const key = `f${this.state.footnoteCount}`;
     this.state.footnotes.push({ key, content: node.content });
     this.pushText(`[${key}]`);
   }
 
-  protected footnoteDisplay(_node: FootnoteDisplayNode): void {
+  protected override footnoteDisplay(_node: FootnoteDisplayNode): void {
     this.renderFootnotes();
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { encodeBase, LOWER_ALPHA, UPPER_ALPHA } from "./baseEncoder.ts";
 import type {
   AccordionGroupNode,
   AccordionTabNode,
+  BadgeNode,
   BlockQuoteNode,
   BreakNode,
   BubbleNode,
@@ -22,6 +23,8 @@ import type {
   FigureCaptionNode,
   FigureImageNode,
   FigureNode,
+  FootnoteNode,
+  FootnoteDisplayNode,
   FormattedTextNode,
   HeaderNode,
   HighTechAlertNode,
@@ -53,6 +56,11 @@ import type {
 } from "document-ir";
 import { NodeVisitor } from "document-ir";
 
+interface FootnoteEntry {
+  key: string;
+  content: Node[];
+}
+
 interface TextVisitingState {
   images: Map<string, string>;
   imagesReverse: Map<string, string>;
@@ -60,6 +68,8 @@ interface TextVisitingState {
   links: Map<string, string>;
   linksReverse: Map<string, string>;
   linkCount: number;
+  footnotes: FootnoteEntry[];
+  footnoteCount: number;
   numericDepth: number;
   tocDepth: number;
 }
@@ -93,6 +103,8 @@ export class FixedWidthTextVisitor extends NodeVisitor {
       links: new Map(),
       linksReverse: new Map(),
       linkCount: 0,
+      footnotes: [],
+      footnoteCount: 0,
       numericDepth: 0,
       tocDepth: 0,
     };
@@ -105,16 +117,23 @@ export class FixedWidthTextVisitor extends NodeVisitor {
   private restoreState(parent: FixedWidthTextVisitor) {
     parent.state.imageCount = this.state.imageCount;
     parent.state.linkCount = this.state.linkCount;
+    parent.state.footnoteCount = this.state.footnoteCount;
   }
 
   protected override choose(node: Node): void {
     switch (node.type) {
+      case "badge":
+        return this.badge(node);
       case "code-block":
         return this.codeBlock(node);
       case "code-group":
         return this.codeGroup(node);
       case "accordion-group":
         return this.accordionGroup(node);
+      case "footnote":
+        return this.footnote(node);
+      case "footnote-display":
+        return this.footnoteDisplay(node);
       case "pill":
         return this.pill(node);
       case "style":
@@ -273,6 +292,63 @@ export class FixedWidthTextVisitor extends NodeVisitor {
     // Render content
     this.pushBlockContentBegin();
     this.chooseChildren(node.content);
+    this.pushBlockContentEnd();
+  }
+
+  protected badge(node: BadgeNode): void {
+    let key: string;
+    if (this.state.images.has(node.url)) {
+      key = this.state.images.get(node.url) || "unreachable";
+    } else {
+      this.state.imageCount++;
+      key = `I${this.state.imageCount}`;
+      this.state.images.set(node.url, key);
+      this.state.imagesReverse.set(key, node.url);
+    }
+    this.spaceLazy = true;
+    this.pushText(
+      `[${key}: ${(node.alt || "unspecified").replaceAll(/[\n\r\t]/g, " ")}]`,
+    );
+    this.spaceLazy = true;
+  }
+
+  protected footnote(node: FootnoteNode): void {
+    this.state.footnoteCount++;
+    const key = `f${this.state.footnoteCount}`;
+    this.state.footnotes.push({ key, content: node.content });
+    this.pushText(`[${key}]`);
+  }
+
+  protected footnoteDisplay(_node: FootnoteDisplayNode): void {
+    this.renderFootnotes();
+  }
+
+  private renderFootnotes(): void {
+    if (this.state.footnotes.length === 0) {return;}
+
+    this.pushBlockContentBegin();
+    const lastKey = this.state.footnotes[this.state.footnotes.length - 1]!.key;
+    const length = `[${lastKey}]: `.length;
+    for (const fn of this.state.footnotes) {
+      const label = `[${fn.key}]: `;
+      const visitor = new FixedWidthTextVisitor(this.width - length);
+      visitor.setState({ ...this.state, numericDepth: 0 });
+      visitor.visit({ type: "array", content: fn.content });
+      let firstLine = true;
+      for (const line of visitor.getLines()) {
+        this.pushEndOfLineIfAnyContent();
+        if (firstLine) {
+          this.lines[Math.max(0, this.lines.length - 1)] =
+            " ".repeat(length - label.length) + label + line;
+          firstLine = false;
+        } else {
+          this.lines[Math.max(0, this.lines.length - 1)] =
+            " ".repeat(length) + line;
+        }
+      }
+      visitor.restoreState(this);
+    }
+    this.state.footnotes = [];
     this.pushBlockContentEnd();
   }
 
@@ -1199,6 +1275,7 @@ export class FixedWidthTextVisitor extends NodeVisitor {
       this.chooseChildren(node.definitions);
     }
     this.afterBlock();
+    this.renderFootnotes();
     this.pushLine();
     if (this.state.linkCount > 0) {
       this.beforeBlock();


### PR DESCRIPTION
## Summary
- Upgrades `document-ir` dependency from `0.3.0` to `0.4.0`
- Adds **badge** node rendering — inline image references like emoji, with URL listed in document-end image references
- Adds **footnote** node rendering — inline `[f1]` references with content stored for later display
- Adds **footnote-display** node — renders accumulated footnotes at an explicit boundary, then clears them so they are not duplicated
- At document end, any remaining un-displayed footnotes render above links and images
- 12 new tests covering badge, footnote, footnote-display, wrapping, ordering, and no-double-rendering

Fixes #9

## Example

**Input** (`example.json`, run with `bun run to-text -- example.json 60`):

```json
{
  "type": "document",
  "title": "Lorem Ipsum with Footnotes",
  "url": "/example",
  "content": [
    {
      "type": "paragraph",
      "content": [
        { "type": "text", "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit." },
        {
          "type": "footnote",
          "content": [{ "type": "text", "text": "From the original Latin text by Cicero, De Finibus Bonorum et Malorum." }]
        },
        { "type": "text", "text": " Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris." }
      ]
    },
    {
      "type": "paragraph",
      "content": [
        { "type": "text", "text": "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur." },
        {
          "type": "footnote",
          "content": [{ "type": "text", "text": "This phrase is commonly used in typesetting since the 1500s." }]
        },
        { "type": "text", "text": " Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." },
        {
          "type": "footnote",
          "content": [{ "type": "text", "text": "The standard Lorem Ipsum passage ends here." }]
        }
      ]
    },
    {
      "type": "paragraph",
      "content": [
        { "type": "text", "text": "Curabitur pretium tincidunt lacus. Nulla gravida orci a odio." },
        {
          "type": "footnote",
          "content": [{ "type": "text", "text": "Additional placeholder text beyond the classical excerpt." }]
        },
        { "type": "text", "text": " Nullam varius, turpis et commodo pharetra, est eros bibendum elit, nec luctus magna felis sollicitudin mauris." }
      ]
    }
  ]
}
```

**Output** (60 columns):

```
                 Lorem Ipsum with Footnotes
------------------------------------------------------------

Lorem ipsum dolor sit amet, consectetur adipiscing elit.[f1]
Sed do eiusmod tempor incididunt ut labore et dolore magna
aliqua. Ut enim ad minim veniam, quis nostrud exercitation
ullamco laboris.

Duis aute irure dolor in reprehenderit in voluptate velit
esse cillum dolore eu fugiat nulla pariatur.[f2] Excepteur
sint occaecat cupidatat non proident, sunt in culpa qui
officia deserunt mollit anim id est laborum.[f3]

Curabitur pretium tincidunt lacus. Nulla gravida orci a
odio.[f4] Nullam varius, turpis et commodo pharetra, est
eros bibendum elit, nec luctus magna felis sollicitudin
mauris.

------------------------------------------------------------

[f1]: From the original Latin text by Cicero, De Finibus
      Bonorum et Malorum.
[f2]: This phrase is commonly used in typesetting since the
      1500s.
[f3]: The standard Lorem Ipsum passage ends here.
[f4]: Additional placeholder text beyond the classical
      excerpt.
```

## Test plan
- [x] All 113 tests pass (`bun test`)
- [x] Badge renders inline with image reference key and URL at document end
- [x] Badge deduplicates same URLs
- [x] Footnote renders inline `[f1]` reference with sequential numbering
- [x] Footnote-display renders accumulated footnotes and clears them
- [x] Footnote-display does not double-render across sections (5 + 6 footnotes test)
- [x] Footnotes in document render above links and images
- [x] Long footnote content wraps with proper indentation
- [x] Empty footnote-display (no footnotes) renders nothing