### PR TITLE
feat: add bluesky social node support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "text-doc-ir",
       "dependencies": {
-        "document-ir": "0.4.0",
+        "document-ir": "0.5.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -187,7 +187,7 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "document-ir": ["document-ir@0.4.0", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-i6guneOvxlYgd2fnlQ9eQGZBkKjyPFdPNk6JenamGiVESZ5NwZsjV7fhZ6tGrkHGaY3jkd3CfBZAtsLg+6hECg=="],
+    "document-ir": ["document-ir@0.5.0", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-AIWaohVjVswbhH46i3mBLiergfEUfpxUmLE3nqYazigmZLxIR4BO8aoK/D9EAK4KdBbISX3ECQSbJ2fIZPudvg=="],
 
     "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "to-text": "bun src/to-text.ts"
   },
   "dependencies": {
-    "document-ir": "0.4.0"
+    "document-ir": "0.5.0"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/src/main.ts
+++ b/src/main.ts
@@ -701,6 +701,13 @@ export class FixedWidthTextVisitor extends NodeVisitor {
           content: [{ type: "text", text: "Toot" }],
         });
         break;
+      case "bluesky":
+        this.link({
+          type: "link",
+          url: `https://bsky.app/post/${node.id}`,
+          content: [{ type: "text", text: "Bluesky Post" }],
+        });
+        break;
       case "vimeo":
         this.link({
           type: "link",


### PR DESCRIPTION
## Summary
- Upgrade document-ir from 0.4.0 to 0.5.0
- Add `bluesky` case to `social()` switch, rendering as a link to `bsky.app/post/{id}`

## Test plan
- All 113 existing tests pass
- Build succeeds