### PR TITLE
fix: skip @domain suffix when usernameDomain is null

### DIFF
--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -1583,6 +1583,34 @@ test("Sticker Center", () => {
   ]);
 });
 
+test("Card with null usernameDomain", () => {
+  const visitor = new FixedWidthTextVisitor(40);
+  visitor.visit({
+    type: "card",
+    header: {
+      type: "card-header",
+      title: [{ type: "text", text: "Sirius" }],
+      username: "smolunicorn1.bsky.social",
+    },
+    content: {
+      type: "card-content",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Hello world" }],
+        },
+      ],
+    },
+  } as any);
+  expect(visitor.getLines()).toEqual([
+    "/--------------------------------------\\",
+    "|   Sirius @smolunicorn1.bsky.social   |",
+    "|--------------------------------------|",
+    "| Hello world                          |",
+    "\\--------------------------------------/",
+  ]);
+});
+
 test("Document - 1", () => {
   const visitor = new FixedWidthTextVisitor(40);
   visitor.visit({

--- a/src/main.ts
+++ b/src/main.ts
@@ -1039,7 +1039,7 @@ export class FixedWidthTextVisitor extends NodeVisitor {
                 type: "text",
                 text: ` @${node.header.username}`,
               } as TextNode] || []),
-          ...(node.header.username &&
+          ...(node.header.usernameDomain &&
               [{
                 type: "text",
                 text: `@${node.header.usernameDomain}`,


### PR DESCRIPTION
## Summary
- Fix card header rendering showing `@undefined` when `usernameDomain` is null/undefined
- The condition guarding the domain text node now checks `usernameDomain` instead of `username`
- Added test for card with null usernameDomain

## Test plan
- [x] All 114 tests pass including new test case