### PR TITLE
fix: update document-ir to 0.5.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "text-doc-ir",
       "dependencies": {
-        "document-ir": "0.5.0",
+        "document-ir": "0.5.4",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -187,7 +187,7 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "document-ir": ["document-ir@0.5.0", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-AIWaohVjVswbhH46i3mBLiergfEUfpxUmLE3nqYazigmZLxIR4BO8aoK/D9EAK4KdBbISX3ECQSbJ2fIZPudvg=="],
+    "document-ir": ["document-ir@0.5.4", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-mFjCVXhP2744okXXJxIjjnnTufSY6QSpgRzhkfQR2xcW7tnpqtFTf6xiSmB28eTiODxhgiAmJGp07OqhsQDw8A=="],
 
     "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "to-text": "bun src/to-text.ts"
   },
   "dependencies": {
-    "document-ir": "0.5.0"
+    "document-ir": "0.5.4"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/src/main.ts
+++ b/src/main.ts
@@ -172,7 +172,7 @@ export class FixedWidthTextVisitor extends NodeVisitor {
     this.pushBlockContentEnd();
   }
 
-  protected codeBlock(node: CodeBlockNode): void {
+  protected override codeBlock(node: CodeBlockNode): void {
     if (node.collapsable && node.collapsed) {
       this.pushBlockContentBegin();
       this.pushText(`[Collapsed: ${node.fileName}]`);
@@ -214,7 +214,7 @@ export class FixedWidthTextVisitor extends NodeVisitor {
     this.pushBlockContentEnd();
   }
 
-  protected codeGroup(node: CodeGroupNode): void {
+  protected override codeGroup(node: CodeGroupNode): void {
     for (const tab of node.tabs) {
       // Render header text
       const headerVisitor = new FixedWidthTextVisitor(this.width);
@@ -259,13 +259,13 @@ export class FixedWidthTextVisitor extends NodeVisitor {
     }
   }
 
-  protected accordionGroup(node: AccordionGroupNode): void {
+  protected override accordionGroup(node: AccordionGroupNode): void {
     for (const tab of node.tabs) {
       this.accordionTab(tab);
     }
   }
 
-  protected accordionTab(node: AccordionTabNode): void {
+  protected override accordionTab(node: AccordionTabNode): void {
     if (node.open === false) {
       this.pushBlockContentBegin();
       const headerVisitor = new FixedWidthTextVisitor(this.width);
@@ -346,7 +346,7 @@ export class FixedWidthTextVisitor extends NodeVisitor {
     this.pushBlockContentEnd();
   }
 
-  protected pill(node: PillNode): void {
+  protected override pill(node: PillNode): void {
     this.pushText("[");
     this.chooseChildren(node.content);
     this.pushText("]");
@@ -929,11 +929,13 @@ export class FixedWidthTextVisitor extends NodeVisitor {
 
     const visitor = new FixedWidthTextVisitor(this.width - 2);
     visitor.setState({ ...this.state, numericDepth: 0 });
+    const attribution: Node[] = node.author
+      ? [{ type: "text", text: node.author }, { type: "break" }, { type: "text", text: node.name }, { type: "break" }]
+      : [{ type: "text", text: node.name }, { type: "break" }];
     visitor.visit({
       type: "array",
       content: [
-        { type: "text", text: node.name },
-        { type: "break" },
+        ...attribution,
         { type: "break" },
         ...node.content,
       ],


### PR DESCRIPTION
## Summary
- Bump `document-ir` dependency from `0.5.0` to `0.5.4`
- Add `override` modifier to `codeBlock`, `codeGroup`, `accordionGroup`, `accordionTab`, and `pill` methods — the base `NodeVisitor` now declares these, so TypeScript requires explicit `override`
- Display the new optional `author` field on `QuoteNode` above the `name` in the text rendering

## Changes in document-ir 0.5.0 → 0.5.4
- `NodeVisitor` base class gained default implementations for `codeBlock`, `codeGroup`, `accordionGroup`, `codeGroupTab`, `pill`, and `style`
- `QuoteNode` gained an optional `author` field (human-readable display name)
- `WhitespaceStretchingTransformer` now handles `emoji` and `badge` nodes
- `WordCounterTransformer` now uses `htmlId || id` for heading IDs

## Test plan
- [x] `bun test` — 114 tests pass
- [x] `bun run type-check` — no errors