### PR TITLE
feat: add admonition node support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "text-doc-ir",
       "dependencies": {
-        "document-ir": "0.5.4",
+        "document-ir": "0.6.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -187,7 +187,7 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "document-ir": ["document-ir@0.5.4", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-mFjCVXhP2744okXXJxIjjnnTufSY6QSpgRzhkfQR2xcW7tnpqtFTf6xiSmB28eTiODxhgiAmJGp07OqhsQDw8A=="],
+    "document-ir": ["document-ir@0.6.0", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-ikXhFXcQO0j+duOMmNcpnPq7WbRK2saUs5yVgz6wjs9FIGiXIxSDqzD0yhVUbCvd4F/0BXV/pk0A897p1ueiUg=="],
 
     "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "to-text": "bun src/to-text.ts"
   },
   "dependencies": {
-    "document-ir": "0.5.4"
+    "document-ir": "0.6.0"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -1281,6 +1281,138 @@ test("Note", () => {
   ]);
 });
 
+test("Admonition block with default label", () => {
+  const visitor = new FixedWidthTextVisitor(40);
+  visitor.visit({
+    type: "admonition",
+    admonitionType: "note",
+    content: [
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+          },
+        ],
+      },
+    ],
+  });
+  expect(visitor.getLines()).toEqual([
+    "!!! note",
+    "    Lorem ipsum dolor sit amet,",
+    "    consectetur adipiscing elit.",
+  ]);
+});
+
+test("Admonition block with custom title", () => {
+  const visitor = new FixedWidthTextVisitor(40);
+  visitor.visit({
+    type: "admonition",
+    admonitionType: "tip",
+    title: [{ type: "text", text: "Pro Tip" }],
+    content: [
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: "This is a helpful tip for you.",
+          },
+        ],
+      },
+    ],
+  });
+  expect(visitor.getLines()).toEqual([
+    '!!! tip "Pro Tip"',
+    "    This is a helpful tip for you.",
+  ]);
+});
+
+test("Admonition block danger type", () => {
+  const visitor = new FixedWidthTextVisitor(40);
+  visitor.visit({
+    type: "admonition",
+    admonitionType: "danger",
+    content: [
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: "Do not do this.",
+          },
+        ],
+      },
+    ],
+  });
+  expect(visitor.getLines()).toEqual([
+    "!!! danger",
+    "    Do not do this.",
+  ]);
+});
+
+test("Admonition inline with default label", () => {
+  const visitor = new FixedWidthTextVisitor(40);
+  visitor.visit({
+    type: "paragraph",
+    content: [
+      { type: "text", text: "See " },
+      {
+        type: "admonition",
+        admonitionType: "info",
+        inline: true,
+        content: [{ type: "text", text: "this detail" }],
+      },
+      { type: "text", text: " here." },
+    ],
+  });
+  expect(visitor.getLines()).toEqual([
+    "See [info: this detail] here.",
+  ]);
+});
+
+test("Admonition inline with custom title", () => {
+  const visitor = new FixedWidthTextVisitor(40);
+  visitor.visit({
+    type: "paragraph",
+    content: [
+      {
+        type: "admonition",
+        admonitionType: "warning",
+        inline: true,
+        title: [{ type: "text", text: "Caution" }],
+        content: [{ type: "text", text: "hot surface" }],
+      },
+    ],
+  });
+  expect(visitor.getLines()).toEqual([
+    "[Caution: hot surface]",
+  ]);
+});
+
+test("Admonition block collapsable and collapsed are ignored in text", () => {
+  const visitor = new FixedWidthTextVisitor(40);
+  visitor.visit({
+    type: "admonition",
+    admonitionType: "tip",
+    collapsable: true,
+    collapsed: true,
+    content: [
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "Still visible in text." },
+        ],
+      },
+    ],
+  });
+  expect(visitor.getLines()).toEqual([
+    "!!! tip",
+    "    Still visible in text.",
+  ]);
+});
+
 test("Center", () => {
   const visitor = new FixedWidthTextVisitor(40);
   visitor.visit({

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { encodeBase, LOWER_ALPHA, UPPER_ALPHA } from "./baseEncoder.ts";
 import type {
   AccordionGroupNode,
   AccordionTabNode,
+  AdmonitionNode,
   BadgeNode,
   BlockQuoteNode,
   BreakNode,
@@ -858,6 +859,46 @@ export class FixedWidthTextVisitor extends NodeVisitor {
     }
     visitor.restoreState(this);
 
+    this.pushBlockContentEnd();
+  }
+
+  protected override admonition(node: AdmonitionNode): void {
+    const label = node.admonitionType;
+    if (node.inline) {
+      if (node.title) {
+        const titleVisitor = new FixedWidthTextVisitor(this.width);
+        titleVisitor.setState({ ...this.state, numericDepth: 0 });
+        titleVisitor.visit({ type: "array", content: node.title });
+        titleVisitor.restoreState(this);
+        const titleText = titleVisitor.getLines().join(" ");
+        this.pushText("[" + titleText + ": ");
+      } else {
+        this.pushText("[" + label + ": ");
+      }
+      this.chooseChildren(node.content);
+      this.pushText("]");
+      return;
+    }
+    // Block mode: !!! type "Title"
+    this.pushBlockContentBegin();
+    if (node.title) {
+      const titleVisitor = new FixedWidthTextVisitor(this.width - 4);
+      titleVisitor.setState({ ...this.state, numericDepth: 0 });
+      titleVisitor.visit({ type: "array", content: node.title });
+      titleVisitor.restoreState(this);
+      const titleText = titleVisitor.getLines().join(" ");
+      this.pushText("!!! " + label + ' "' + titleText + '"');
+    } else {
+      this.pushText("!!! " + label);
+    }
+    const visitor = new FixedWidthTextVisitor(this.width - 4);
+    visitor.setState({ ...this.state, numericDepth: 0 });
+    visitor.visit({ type: "array", content: node.content });
+    for (const line of visitor.getLines()) {
+      this.pushEndOfLineIfAnyContent();
+      this.lines[Math.max(0, this.lines.length - 1)] = "    " + line;
+    }
+    visitor.restoreState(this);
     this.pushBlockContentEnd();
   }
 


### PR DESCRIPTION
## Summary
- Updates document-ir dependency from 0.5.4 to 0.6.0
- Implements text rendering for `AdmonitionNode` with MkDocs-style block syntax (`!!! type` with 4-space indented content)
- Supports optional custom title via `!!! type "Title"` syntax
- Inline admonitions render as `[label: content]` or `[Title: content]`
- Collapsable/collapsed properties are ignored in text output (content always shown)

## Test plan
- [x] All 120 tests pass (`bun test`)
- [x] Build succeeds (`bun run build`)
- [x] Block admonition with default label
- [x] Block admonition with custom title
- [x] Block admonition with danger type
- [x] Inline admonition with default label
- [x] Inline admonition with custom title
- [x] Collapsable/collapsed ignored in text output